### PR TITLE
Cursor error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # VSCode
 .vscode
+.idea
 
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
@@ -26,3 +27,4 @@ go.work
 
 .env
 data/
+jetstream

--- a/cmd/jetstream/main.go
+++ b/cmd/jetstream/main.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,6 +28,57 @@ import (
 
 	"github.com/urfave/cli/v2"
 )
+
+func getBackupFileName(cursorFilePath string) string {
+	timestamp := time.Now().Format("20060102-150405")
+	dir, _ := filepath.Split(cursorFilePath)
+	return filepath.Join(dir, fmt.Sprintf("%s-cursor-backup.json", timestamp))
+}
+
+func checkAndDeleteOldBackups(cursorFilePath string, log slog.Logger) {
+	log.Info("Created cursor backup. Checking old backups.")
+
+	dir := filepath.Dir(cursorFilePath)
+
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		log.Error("failed to read directory", "error", err)
+		return
+	}
+
+	var backups []fs.DirEntry
+	for _, v := range dirEntries {
+		if v.IsDir() {
+			continue
+		}
+		if strings.Contains(v.Name(), "-cursor-backup.json") {
+			backups = append(backups, v)
+		}
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		infoI, errI := backups[i].Info()
+		infoJ, errJ := backups[j].Info()
+		if errI != nil {
+			log.Error("failed to get file info", "error", errI, "file", backups[i].Name())
+			return false
+		}
+		if errJ != nil {
+			log.Error("failed to get file info", "error", errJ, "file", backups[j].Name())
+			return false
+		}
+		return infoI.ModTime().Before(infoJ.ModTime())
+	})
+
+	for len(backups) > 10 {
+		err = os.Remove(filepath.Join(dir, backups[0].Name()))
+		if err != nil {
+			log.Error("failed to remove old backup", "error", err, "file", backups[0].Name())
+			return
+		}
+		backups = backups[1:]
+	}
+}
 
 func main() {
 	app := cli.App{
@@ -139,6 +194,7 @@ func Jetstream(cctx *cli.Context) error {
 	cursorManagerShutdown := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
+		backupTicker := time.NewTicker(5 * time.Minute)
 		log := log.With("source", "cursor_manager")
 
 		for {
@@ -156,6 +212,14 @@ func Jetstream(cctx *cli.Context) error {
 				err := c.WriteCursor(ctx)
 				if err != nil {
 					log.Error("failed to write cursor", "error", err)
+				}
+			case <-backupTicker.C:
+				backupFileName := getBackupFileName(c.Progress.GetPath())
+				err := c.WriteCursorToFile(ctx, backupFileName)
+				if err != nil {
+					log.Error("failed to create cursor backup", "error", err)
+				} else {
+					checkAndDeleteOldBackups(c.Progress.GetPath(), *log)
 				}
 			}
 		}

--- a/pkg/consumer/event.go
+++ b/pkg/consumer/event.go
@@ -6,6 +6,7 @@ type Event struct {
 	OpType     string `json:"opType"`
 	Collection string `json:"collection,omitempty"`
 	RKey       string `json:"rkey,omitempty"`
+	Cid        string `json:"cid,omitempty"`
 
 	Record any `json:"record,omitempty"`
 }


### PR DESCRIPTION
Addresses #2 

Add functions for creating backups and their file names every 5 minutes, up to 10 backups. 
Add startup logic to attempt loading original cursor, fall back to backups, then fall back to live, instead of shutting down.

Unrelated, but I also found that having the Cid is super helpful for most requests, so I added it to the Event.